### PR TITLE
Refactor LTV check

### DIFF
--- a/src/PreLiquidation.sol
+++ b/src/PreLiquidation.sol
@@ -128,7 +128,7 @@ contract PreLiquidation is IPreLiquidation, IMorphoRepayCallback {
         uint256 borrowed = uint256(position.borrowShares).toAssetsUp(market.totalBorrowAssets, market.totalBorrowShares);
         uint256 ltv = borrowed.wDivUp(collateralQuoted);
 
-        // The following require is equivalent to checking that borrowed > collateralQuoted.wMulDown(PRE_LLTV)
+        // The following require is equivalent to checking that borrowed > collateralQuoted.wMulDown(PRE_LLTV).
         require(ltv > PRE_LLTV, ErrorsLib.NotPreLiquidatablePosition());
 
         uint256 preLIF = UtilsLib.min(


### PR DESCRIPTION
This refactor should be functionally equivalent to the previous one, which is verified [here](https://prover.certora.com/output/66603/ee77f1306dd14be48b6bc0081283a7b0?anonymousKey=7b003cd484ca1863551277eade125148e63702cb).

Motivation to do this refactor:
- it makes it clearer why the computation `ltv - PRE_LLTV` won't revert
- it makes the computation more efficient
- we can document and verify that it is functionally the same as before