### PR TITLE
Add guard

### DIFF
--- a/src/interfaces/IPreLiquidation.sol
+++ b/src/interfaces/IPreLiquidation.sol
@@ -8,11 +8,13 @@ import {Id, IMorpho, MarketParams} from "../../lib/morpho-blue/src/interfaces/IM
 ///  - closeFactor, the maximum proportion of debt that can be pre-liquidated at once.
 ///  - preLiquidationIncentiveFactor, the factor used to multiply repaid debt value to get the seized collateral value in a pre-liquidation.
 ///  - preLiquidationOracle, the oracle used to assess whether or not a position can be preliquidated.
+///  - preLiquidator, if set, the only account authorized to pre-liquidate.
 struct PreLiquidationParams {
     uint256 preLltv;
     uint256 closeFactor;
     uint256 preLiquidationIncentiveFactor;
     address preLiquidationOracle;
+    address preLiquidator;
 }
 
 interface IPreLiquidation {

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -10,6 +10,8 @@ import {Id} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 library ErrorsLib {
     /* PRELIQUIDATION ERRORS */
 
+    error UnauthorizedLiquidator();
+
     error PreLltvTooHigh();
 
     error CloseFactorTooHigh();

--- a/test/PreLiquidationTest.sol
+++ b/test/PreLiquidationTest.sol
@@ -109,6 +109,7 @@ contract PreLiquidationTest is BaseTest, IPreLiquidationCallback {
         preLiquidationParams.preLiquidationIncentiveFactor =
             WAD + bound(preLiquidationParams.preLiquidationIncentiveFactor, 0, WAD / 10);
         preLiquidationParams.preLiquidationOracle = marketParams.oracle;
+        preLiquidationParams.preLiquidator = address(0);
 
         collateralAmount = bound(collateralAmount, 10 ** 18, 10 ** 24);
         uint256 collateralPrice = IOracle(marketParams.oracle).price();
@@ -150,6 +151,7 @@ contract PreLiquidationTest is BaseTest, IPreLiquidationCallback {
         preLiquidationParams.preLiquidationIncentiveFactor =
             WAD + bound(preLiquidationParams.preLiquidationIncentiveFactor, 0, WAD / 10);
         preLiquidationParams.preLiquidationOracle = marketParams.oracle;
+        preLiquidationParams.preLiquidator = address(0);
 
         collateralAmount = bound(collateralAmount, 10 ** 18, 10 ** 24);
 
@@ -198,6 +200,7 @@ contract PreLiquidationTest is BaseTest, IPreLiquidationCallback {
         preLiquidationParams.preLiquidationIncentiveFactor =
             WAD + bound(preLiquidationParams.preLiquidationIncentiveFactor, 0, WAD / 10);
         preLiquidationParams.preLiquidationOracle = marketParams.oracle;
+        preLiquidationParams.preLiquidator = address(0);
 
         collateralAmount = bound(collateralAmount, 10 ** 18, 10 ** 24);
 


### PR DESCRIPTION
The idea is that it would allow to build on top of the pre-liquidation contract, with the following use cases for example:
- make sure that liquidators are whitelisted
- give other pre-liquidation parameters or add more checks