### PR TITLE
[Certora] Simplify setup

### DIFF
--- a/certora/confs/MarketExists.conf
+++ b/certora/confs/MarketExists.conf
@@ -1,18 +1,18 @@
 {
   "files": [
-    "src/PreLiquidation.sol",
-    "lib/morpho-blue/src/Morpho.sol"
+    "lib/morpho-blue/certora/harness/MorphoHarness.sol",
+    "src/PreLiquidation.sol"
   ],
   "link": [
-    "PreLiquidation:MORPHO=Morpho"
+    "PreLiquidation:MORPHO=MorphoHarness"
   ],
   "parametric_contracts": [
-    "Morpho"
+    "MorphoHarness"
   ],
   "solc_optimize": "99999",
   "solc_via_ir": true,
   "solc_map": {
-    "Morpho": "solc-0.8.19",
+    "MorphoHarness": "solc-0.8.19",
     "PreLiquidation": "solc-0.8.27"
   },
   "verify": "PreLiquidation:certora/specs/MarketExists.spec",

--- a/certora/specs/ConsistentInstantiation.spec
+++ b/certora/specs/ConsistentInstantiation.spec
@@ -48,7 +48,7 @@ invariant preLIFNotZero()
 invariant preLIFConsistent()
     WAD() < currentContract.PRE_LIF_1
     && currentContract.PRE_LIF_1 <= currentContract.PRE_LIF_2
-    && currentContract.PRE_LIF_2 <= summaryWDivDown(WAD(),currentContract.LLTV)
+    && currentContract.PRE_LIF_2 <= summaryWDivDown(WAD(), currentContract.LLTV)
 {
     preserved {
         requireInvariant lltvNotZero();

--- a/certora/specs/ConsistentInstantiation.spec
+++ b/certora/specs/ConsistentInstantiation.spec
@@ -5,8 +5,7 @@ import "SummaryLib.spec";
 methods {
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
 
-    function Util.libId(PreLiquidation.MarketParams) external
-        returns PreLiquidation.Id envfree;
+    function Util.libId(PreLiquidation.MarketParams) external returns PreLiquidation.Id envfree;
 }
 
 //Ensure constructor requirements.

--- a/certora/specs/ConsistentInstantiation.spec
+++ b/certora/specs/ConsistentInstantiation.spec
@@ -8,7 +8,7 @@ methods {
     function Util.libId(PreLiquidation.MarketParams) external returns PreLiquidation.Id envfree;
 }
 
-//Ensure constructor requirements.
+// Ensure constructor requirements.
 
 // Base case for mutually dependent invariants.
 // Ensure that in a successfully deployed contract the preLLTV value is not zero.

--- a/certora/specs/ConsistentInstantiation.spec
+++ b/certora/specs/ConsistentInstantiation.spec
@@ -3,9 +3,8 @@
 import "SummaryLib.spec";
 
 methods {
+    // To fix an issue where immutable variables are not linked in the constructor.
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
-
-    function Util.libId(PreLiquidation.MarketParams) external returns (PreLiquidation.Id) envfree;
 }
 
 // Ensure constructor requirements.

--- a/certora/specs/ConsistentInstantiation.spec
+++ b/certora/specs/ConsistentInstantiation.spec
@@ -5,7 +5,7 @@ import "SummaryLib.spec";
 methods {
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
 
-    function Util.libId(PreLiquidation.MarketParams) external returns PreLiquidation.Id envfree;
+    function Util.libId(PreLiquidation.MarketParams) external returns (PreLiquidation.Id) envfree;
 }
 
 // Ensure constructor requirements.

--- a/certora/specs/Liveness.spec
+++ b/certora/specs/Liveness.spec
@@ -24,7 +24,6 @@ rule preLiquidateRepays(method f, env e, calldataarg data) {
     // Safe require because Morpho cannot send transactions.
     require e.msg.sender != currentContract.MORPHO;
 
-
     // Capture the first method call which is not performed with a CALL opcode.
     if (f.selector == sig:preLiquidate(address, uint256, uint256, bytes).selector) {
        preLiquidateCalled = true;

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -3,8 +3,9 @@
 using Morpho as MORPHO;
 
 methods {
-    function _.market(PreLiquidation.Id) external => DISPATCHER(true);
+    function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;
     function MORPHO.market(PreLiquidation.Id) external returns (uint128, uint128, uint128, uint128, uint128, uint128) envfree;
+    function _.market(PreLiquidation.Id) external => DISPATCHER(true);
     function _.price() external => NONDET;
 }
 
@@ -18,13 +19,7 @@ hook TIMESTAMP uint newTimestamp {
     lastTimestamp = newTimestamp;
 }
 
-function lastUpdateIsNotNil(PreLiquidation.Id id) returns bool {
-    mathint lastUpdate;
-    (_,_,_,_,lastUpdate,_) = MORPHO.market(id);
-    return lastUpdate != 0;
-}
-
 // Ensure that the pre-liquidation contract interacts with a created market.
 
 invariant marketExists()
-    lastUpdateIsNotNil(currentContract.ID);
+    MORPHO.lastUpdate(currentContract.ID) != 0

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -4,9 +4,8 @@ using MorphoHarness as MORPHO;
 
 methods {
     function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;
-    function MORPHO.market(PreLiquidation.Id) external returns (uint128, uint128, uint128, uint128, uint128, uint128) envfree;
+    // To fix an issue where immutable variables are not linked in the constructor.
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
-    function _.price() external => NONDET;
 }
 
 persistent ghost uint256 lastTimestamp;

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -22,4 +22,4 @@ hook TIMESTAMP uint newTimestamp {
 // Ensure that the pre-liquidation contract interacts with a created market.
 
 invariant marketExists()
-    MORPHO.lastUpdate(currentContract.ID) != 0
+    MORPHO.lastUpdate(currentContract.ID) != 0;

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -4,7 +4,7 @@ using Morpho as MORPHO;
 
 methods {
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
-    function MORPHO.market(PreLiquidation.Id) external returns (uint128, uint128, uint128,uint128, uint128, uint128) envfree;
+    function MORPHO.market(PreLiquidation.Id) external returns (uint128, uint128, uint128, uint128, uint128, uint128) envfree;
     function _.price() external => NONDET;
 }
 

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-using Morpho as MORPHO;
+using MorphoHarness as MORPHO;
 
 methods {
     function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;

--- a/certora/specs/MarketExists.spec
+++ b/certora/specs/MarketExists.spec
@@ -4,8 +4,7 @@ using Morpho as MORPHO;
 
 methods {
     function _.market(PreLiquidation.Id) external => DISPATCHER(true);
-    function MORPHO.market(PreLiquidation.Id) external
-      returns (uint128, uint128, uint128,uint128, uint128, uint128) envfree;
+    function MORPHO.market(PreLiquidation.Id) external returns (uint128, uint128, uint128,uint128, uint128, uint128) envfree;
     function _.price() external => NONDET;
 }
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -33,7 +33,7 @@ rule zeroCollateralQuotedReverts(env e, address borrower, uint256 seizedAssets, 
     uint256 higherBound = summaryWMulDown(collateralQuoted, currentContract.LLTV);
     uint256 lowerBound = summaryWMulDown(collateralQuoted, currentContract.PRE_LLTV);
 
-    assert  collateralQuoted == 0 => (lowerBound >= borrowed || borrowed > higherBound);
+    assert collateralQuoted == 0 => (lowerBound >= borrowed || borrowed > higherBound);
 }
 
 // Check that pre-liquidating a position such that LTV <= PRE_LLTV reverts.
@@ -101,13 +101,13 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
     uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);
     mathint repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, require_uint256(preLIF)), totalShares, totalAssets);
 
-    mathint closeFactor = computeLinearCombination(ltv,
+    mathint preLCF = computeLinearCombination(ltv,
                                                    currentContract.LLTV,
                                                    currentContract.PRE_LLTV,
                                                    currentContract.PRE_LCF_1,
                                                    currentContract.PRE_LCF_2) ;
 
-    mathint repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), require_uint256(closeFactor));
+    mathint repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), require_uint256(preLCF));
 
     preLiquidate@withrevert(e, borrower, seizedAssets, 0, data);
 
@@ -132,13 +132,13 @@ rule excessivePreliquidationWithSharesReverts(env e, address borrower, uint256 r
 
     mathint ltv = getLtv(borrower);
 
-    mathint closeFactor = computeLinearCombination(ltv,
+    mathint preLCF = computeLinearCombination(ltv,
                                                    currentContract.LLTV,
                                                    currentContract.PRE_LLTV,
                                                    currentContract.PRE_LCF_1,
                                                    currentContract.PRE_LCF_2);
 
-    mathint repayableShares = summaryWMulDown(borrowerShares, require_uint256(closeFactor));
+    mathint repayableShares = summaryWMulDown(borrowerShares, require_uint256(preLCF));
 
     preLiquidate@withrevert(e, borrower, 0, repaidShares, data);
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -47,7 +47,7 @@ rule nonLiquidatablePositionReverts(env e, address borrower, uint256 seizedAsset
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
     require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
-    mathint ltv = getLtv(borrower);
+    uint256 ltv = getLtv(borrower);
 
     preLiquidate@withrevert(e, borrower, seizedAssets, 0, data);
 
@@ -67,7 +67,7 @@ rule liquidatablePositionReverts(env e, address borrower, uint256 seizedAssets, 
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
     require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
-    mathint ltv = getLtv(borrower);
+    uint256 ltv = getLtv(borrower);
 
     preLiquidate@withrevert(e, borrower, seizedAssets, 0, data);
 
@@ -87,9 +87,9 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
     require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
-    mathint ltv = getLtv(borrower);
+    uint256 ltv = getLtv(borrower);
 
-    mathint preLIF = computeLinearCombination(ltv,
+    uint256 preLIF = computeLinearCombination(ltv,
                                               currentContract.LLTV,
                                               currentContract.PRE_LLTV,
                                               currentContract.PRE_LIF_1,
@@ -99,15 +99,15 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
 
     uint256 totalAssets = MORPHO.virtualTotalBorrowAssets(currentContract.ID);
     uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);
-    mathint repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, require_uint256(preLIF)), totalShares, totalAssets);
+    uint256 repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, preLIF), totalShares, totalAssets);
 
-    mathint preLCF = computeLinearCombination(ltv,
-                                                   currentContract.LLTV,
-                                                   currentContract.PRE_LLTV,
-                                                   currentContract.PRE_LCF_1,
-                                                   currentContract.PRE_LCF_2) ;
+    uint256 preLCF = computeLinearCombination(ltv,
+                                              currentContract.LLTV,
+                                              currentContract.PRE_LLTV,
+                                              currentContract.PRE_LCF_1,
+                                              currentContract.PRE_LCF_2) ;
 
-    mathint repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), require_uint256(preLCF));
+    mathint repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), preLCF);
 
     preLiquidate@withrevert(e, borrower, seizedAssets, 0, data);
 
@@ -130,15 +130,15 @@ rule excessivePreliquidationWithSharesReverts(env e, address borrower, uint256 r
 
     uint256 borrowerShares = MORPHO.borrowShares(currentContract.ID, borrower);
 
-    mathint ltv = getLtv(borrower);
+    uint256 ltv = getLtv(borrower);
 
-    mathint preLCF = computeLinearCombination(ltv,
-                                                   currentContract.LLTV,
-                                                   currentContract.PRE_LLTV,
-                                                   currentContract.PRE_LCF_1,
-                                                   currentContract.PRE_LCF_2);
+    uint256 preLCF = computeLinearCombination(ltv,
+                                              currentContract.LLTV,
+                                              currentContract.PRE_LLTV,
+                                              currentContract.PRE_LCF_1,
+                                              currentContract.PRE_LCF_2);
 
-    mathint repayableShares = summaryWMulDown(borrowerShares, require_uint256(preLCF));
+    mathint repayableShares = summaryWMulDown(borrowerShares, preLCF);
 
     preLiquidate@withrevert(e, borrower, 0, repaidShares, data);
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -92,18 +92,20 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
 
     mathint ltv = getLtv(borrower);
 
-    mathint preLIF = computeLinearCombination(ltv,
+    uint256 preLIF = require_uint256(computeLinearCombination(ltv,
                                               currentContract.LLTV,
                                               currentContract.PRE_LLTV,
                                               currentContract.PRE_LIF_1,
-                                              currentContract.PRE_LIF_2) ;
+                                              currentContract.PRE_LIF_2));
 
     // Safe require as implementation would revert with InconsistentInput.
     require seizedAssets > 0;
 
-    mathint seizedAssetsQuoted = require_uint256(summaryMulDivUp(seizedAssets, mockPrice(), ORACLE_PRICE_SCALE()));
+    uint256 seizedAssetsQuoted = require_uint256(summaryMulDivUp(seizedAssets, mockPrice(), ORACLE_PRICE_SCALE()));
 
-    mathint repaidShares = summaryToSharesUp(summaryWDivUp(require_uint256(seizedAssetsQuoted), require_uint256(preLIF)));
+    uint256 totalAssets = MORPHO.virtualTotalBorrowAssets(currentContract.ID);
+    uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);
+    mathint repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, preLIF), totalAssets, totalShares);
 
     mathint closeFactor = computeLinearCombination(ltv,
                                                    currentContract.LLTV,

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -46,11 +46,9 @@ rule nonLiquidatablePositionReverts(env e, address borrower, uint256 seizedAsset
     requireInvariant preLCFConsistent();
     requireInvariant preLIFConsistent();
 
-    PreLiquidation.Market m = MORPHO.market_(currentContract.ID);
-
     // Ensure that no interest is accumulated.
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
-    require m.lastUpdate == e.block.timestamp;
+    require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
     mathint ltv = getLtv(borrower);
 
@@ -68,11 +66,9 @@ rule liquidatablePositionReverts(env e, address borrower, uint256 seizedAssets, 
     requireInvariant preLCFConsistent();
     requireInvariant preLIFConsistent();
 
-    PreLiquidation.Market m = MORPHO.market_(currentContract.ID);
-
     // Ensure that no interest is accumulated.
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
-    require m.lastUpdate == e.block.timestamp;
+    require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
     mathint ltv = getLtv(borrower);
 
@@ -132,11 +128,9 @@ rule excessivePreliquidationWithSharesReverts(env e, address borrower, uint256 r
     requireInvariant preLCFConsistent();
     requireInvariant preLIFConsistent();
 
-    PreLiquidation.Market m = MORPHO.market_(currentContract.ID);
-
     // Ensure that no interest is accumulated.
     // Safe require as the invariant ID == marketParams().id() holds, see ConsistentInstantion hashOfMarketParamsOf.
-    require m.lastUpdate == e.block.timestamp;
+    require MORPHO.lastUpdate(currentContract.ID) == e.block.timestamp;
 
     PreLiquidation.Position p = MORPHO.position_(currentContract.ID, borrower);
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -5,10 +5,8 @@ import "ConsistentInstantiation.spec";
 methods {
     function _.price() external => mockPrice() expect uint256;
 
-    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal
-        returns uint256 => summaryMulDivDown(a,b,c);
-    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal
-        returns uint256 => summaryMulDivUp(a,b,c);
+    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivDown(a,b,c);
+    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivUp(a,b,c);
 }
 
 // Checks that onMorphoRepay is only triggered by Morpho.

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -105,7 +105,7 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
 
     uint256 totalAssets = MORPHO.virtualTotalBorrowAssets(currentContract.ID);
     uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);
-    mathint repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, require_uint256(preLIF)), totalAssets, totalShares);
+    mathint repaidShares = summaryMulDivUp(summaryWDivUp(seizedAssetsQuoted, require_uint256(preLIF)), totalShares, totalAssets);
 
     mathint closeFactor = computeLinearCombination(ltv,
                                                    currentContract.LLTV,

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -107,7 +107,7 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
                                               currentContract.PRE_LCF_1,
                                               currentContract.PRE_LCF_2) ;
 
-    mathint repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), preLCF);
+    uint256 repayableShares = summaryWMulDown(MORPHO.borrowShares(currentContract.ID, borrower), preLCF);
 
     preLiquidate@withrevert(e, borrower, seizedAssets, 0, data);
 
@@ -138,7 +138,7 @@ rule excessivePreliquidationWithSharesReverts(env e, address borrower, uint256 r
                                               currentContract.PRE_LCF_1,
                                               currentContract.PRE_LCF_2);
 
-    mathint repayableShares = summaryWMulDown(borrowerShares, preLCF);
+    uint256 repayableShares = summaryWMulDown(borrowerShares, preLCF);
 
     preLiquidate@withrevert(e, borrower, 0, repaidShares, data);
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -4,9 +4,6 @@ import "ConsistentInstantiation.spec";
 
 methods {
     function _.price() external => mockPrice() expect uint256;
-
-    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivDown(a,b,c);
-    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivUp(a,b,c);
 }
 
 // Checks that onMorphoRepay is only triggered by Morpho.
@@ -97,9 +94,6 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
                                               currentContract.PRE_LLTV,
                                               currentContract.PRE_LIF_1,
                                               currentContract.PRE_LIF_2);
-
-    // Safe require as implementation would revert with InconsistentInput.
-    require seizedAssets > 0;
 
     uint256 seizedAssetsQuoted = require_uint256(summaryMulDivUp(seizedAssets, mockPrice(), ORACLE_PRICE_SCALE()));
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -89,13 +89,13 @@ rule excessivePreliquidationWithAssetsReverts(env e, address borrower, uint256 s
 
     mathint ltv = getLtv(borrower);
 
-    uint256 preLIF = computeLinearCombination(ltv,
+    mathint preLIF = computeLinearCombination(ltv,
                                               currentContract.LLTV,
                                               currentContract.PRE_LLTV,
                                               currentContract.PRE_LIF_1,
                                               currentContract.PRE_LIF_2);
 
-    uint256 seizedAssetsQuoted = require_uint256(summaryMulDivUp(seizedAssets, mockPrice(), ORACLE_PRICE_SCALE()));
+    uint256 seizedAssetsQuoted = summaryMulDivUp(seizedAssets, mockPrice(), ORACLE_PRICE_SCALE());
 
     uint256 totalAssets = MORPHO.virtualTotalBorrowAssets(currentContract.ID);
     uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);

--- a/certora/specs/SafeMath.spec
+++ b/certora/specs/SafeMath.spec
@@ -2,11 +2,11 @@
 
 definition WAD() returns mathint = 10^18;
 
-function summaryWMulDown(mathint x,mathint y) returns mathint {
+function summaryWMulDown(mathint x, mathint y) returns mathint {
     return (x * y) / WAD();
 }
 
-function summaryWDivUp(mathint x,mathint y) returns mathint {
+function summaryWDivUp(mathint x, mathint y) returns mathint {
     return (x * WAD() + (y-1)) / y;
 }
 

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -64,7 +64,6 @@ function mockPrice() returns uint256 {
     return updatedPrice;
 }
 
-
 // Ensure this function is only used when no interest is accrued, or enforce that the last update matches the current timestamp.
 function positionAsAssets (address borrower) returns (uint256, uint256) {
     uint256 borrowerShares = MORPHO.borrowShares(currentContract.ID, borrower);
@@ -91,7 +90,8 @@ function getLtv(address borrower) returns uint256 {
     return summaryWDivUp(borrowed, collateralQuoted);
 }
 
-definition computeLinearCombination(mathint ltv, mathint lltv, mathint preLltv, mathint yAtPreLltv, mathint yAtLltv)
-    returns mathint = summaryWMulDown(summaryWDivDown(require_uint256(ltv - preLltv),
-                                                      require_uint256(lltv - preLltv)),
-                                      require_uint256(yAtLltv - yAtPreLltv)) + yAtPreLltv;
+// Safe requires because the implementation would revert.
+definition computeLinearCombination(uint256 ltv, uint256 lltv, uint256 preLltv, uint256 yAtPreLltv, uint256 yAtLltv) returns uint256 =
+    require_uint256(summaryWMulDown(summaryWDivDown(require_uint256(ltv - preLltv),
+                                                    require_uint256(lltv - preLltv)),
+                                    require_uint256(yAtLltv - yAtPreLltv)) + yAtPreLltv);

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -6,12 +6,12 @@ using Util as Util;
 methods {
     function MORPHO.market_(PreLiquidation.Id) external returns (PreLiquidation.Market memory) envfree;
     function MORPHO.position_(PreLiquidation.Id, address) external returns (PreLiquidation.Position memory) envfree;
+    function MORPHO.virtualTotalBorrowAssets(PreLiquidation.Id) external returns(uint256) envfree;
+    function MORPHO.virtualTotalBorrowShares(PreLiquidation.Id) external returns(uint256) envfree;
     function MORPHO.virtualTotalSupplyAssets(PreLiquidation.Id) external returns(uint256) envfree;
     function MORPHO.virtualTotalSupplyShares(PreLiquidation.Id) external returns(uint256) envfree;
     function MORPHO.borrowShares(PreLiquidation.Id, address) external returns (uint256) envfree;
     function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;
-
-    function Util.libMulDivUp(uint256, uint256, uint256) external returns(uint256) envfree;
 }
 
 definition WAD() returns uint256 = 10^18;
@@ -43,12 +43,6 @@ function summaryMulDivUp(uint256 x,uint256 y, uint256 d) returns uint256 {
     // Safe require because the reference implementation would revert.
     return require_uint256((x * y + (d-1)) / d);
 
-}
-
-function summaryToSharesUp(uint256 assets) returns uint256 {
-    uint256 totalAssets = MORPHO.virtualTotalSupplyAssets(currentContract.ID);
-    uint256 totalShares = MORPHO.virtualTotalSupplyShares(currentContract.ID);
-    return Util.libMulDivUp(assets, totalAssets, totalShares);
 }
 
 function summaryToAssetsUp(uint256 shares, uint256 totalAssets, uint256 totalShares) returns uint256 {

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -70,14 +70,14 @@ function positionAsAssets (address borrower) returns (uint256, uint256) {
     uint256 borrowerShares = MORPHO.borrowShares(currentContract.ID, borrower);
     uint256 borrowerCollateral = MORPHO.collateral(currentContract.ID, borrower);
 
-    uint256 collateralQuoted = require_uint256(summaryMulDivDown(borrowerCollateral, mockPrice(), ORACLE_PRICE_SCALE()));
+    uint256 collateralQuoted = summaryMulDivDown(borrowerCollateral, mockPrice(), ORACLE_PRICE_SCALE());
 
     // Safe require because the implementation would revert, see rule zeroCollateralQuotedReverts.
     require collateralQuoted > 0;
 
     uint256 totalAssets = MORPHO.virtualTotalBorrowAssets(currentContract.ID);
     uint256 totalShares = MORPHO.virtualTotalBorrowShares(currentContract.ID);
-    uint256 borrowed = require_uint256(summaryMulDivUp(borrowerShares, totalAssets, totalShares));
+    uint256 borrowed = summaryMulDivUp(borrowerShares, totalAssets, totalShares);
 
     return (borrowed, collateralQuoted);
 }

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -35,7 +35,6 @@ function summaryWDivUp(uint256 x,uint256 y) returns uint256 {
 function summaryMulDivUp(uint256 x,uint256 y, uint256 d) returns uint256 {
     // Safe require because the reference implementation would revert.
     return require_uint256((x * y + (d-1)) / d);
-
 }
 
 function summaryMarketParams() returns PreLiquidation.MarketParams {

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -4,10 +4,8 @@ using MorphoHarness as MORPHO;
 using Util as Util;
 
 methods {
-    function MORPHO.market_(PreLiquidation.Id) external
-        returns (PreLiquidation.Market memory) envfree;
-    function MORPHO.position_(PreLiquidation.Id, address) external
-        returns (PreLiquidation.Position memory) envfree;
+    function MORPHO.market_(PreLiquidation.Id) external returns (PreLiquidation.Market memory) envfree;
+    function MORPHO.position_(PreLiquidation.Id, address) external returns (PreLiquidation.Position memory) envfree;
     function MORPHO.virtualTotalSupplyAssets(PreLiquidation.Id) external returns(uint256) envfree;
     function MORPHO.virtualTotalSupplyShares(PreLiquidation.Id) external returns(uint256) envfree;
     function MORPHO.borrowShares(PreLiquidation.Id, address) external returns (uint256) envfree;

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -25,7 +25,7 @@ function summaryWDivDown(uint256 x,uint256 y) returns uint256 {
 
 function summaryMulDivDown(uint256 x,uint256 y, uint256 d) returns uint256 {
     // Safe require because the reference implementation would revert.
-    return require_uint256((x * y)/d);
+    return require_uint256((x * y) / d);
 }
 
 function summaryWDivUp(uint256 x,uint256 y) returns uint256 {
@@ -34,7 +34,7 @@ function summaryWDivUp(uint256 x,uint256 y) returns uint256 {
 
 function summaryMulDivUp(uint256 x,uint256 y, uint256 d) returns uint256 {
     // Safe require because the reference implementation would revert.
-    return require_uint256((x * y + (d-1)) / d);
+    return require_uint256((x * y + (d - 1)) / d);
 }
 
 function summaryMarketParams() returns PreLiquidation.MarketParams {

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -4,8 +4,8 @@ using MorphoHarness as MORPHO;
 using Util as Util;
 
 methods {
-    function MORPHO.virtualTotalBorrowAssets(PreLiquidation.Id) external returns(uint256) envfree;
-    function MORPHO.virtualTotalBorrowShares(PreLiquidation.Id) external returns(uint256) envfree;
+    function MORPHO.virtualTotalBorrowAssets(PreLiquidation.Id) external returns (uint256) envfree;
+    function MORPHO.virtualTotalBorrowShares(PreLiquidation.Id) external returns (uint256) envfree;
     function MORPHO.borrowShares(PreLiquidation.Id, address) external returns (uint256) envfree;
     function MORPHO.collateral(PreLiquidation.Id, address) external returns (uint256) envfree;
     function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -8,6 +8,12 @@ methods {
         returns (PreLiquidation.Market memory) envfree;
     function MORPHO.position_(PreLiquidation.Id, address) external
         returns (PreLiquidation.Position memory) envfree;
+    function MORPHO.virtualTotalSupplyAssets(PreLiquidation.Id) external returns(uint256) envfree;
+    function MORPHO.virtualTotalSupplyShares(PreLiquidation.Id) external returns(uint256) envfree;
+    function MORPHO.borrowShares(PreLiquidation.Id, address) external returns (uint256) envfree;
+    function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;
+
+    function Util.libMulDivUp(uint256, uint256, uint256) external returns(uint256) envfree;
 }
 
 definition WAD() returns uint256 = 10^18;
@@ -41,16 +47,10 @@ function summaryMulDivUp(uint256 x,uint256 y, uint256 d) returns uint256 {
 
 }
 
-function summaryToAssetsDown(uint256 shares, uint256 totalAssets, uint256 totalShares) returns uint256 {
-    return summaryMulDivDown(shares,
-                             require_uint256(totalAssets + VIRTUAL_ASSETS()),
-                             require_uint256(totalShares + VIRTUAL_SHARES()));
-}
-
-function summaryToSharesUp(uint256 assets, uint256 totalAssets, uint256 totalShares) returns uint256 {
-    return summaryMulDivUp(assets,
-                           require_uint256(totalShares + VIRTUAL_SHARES()),
-                           require_uint256(totalAssets + VIRTUAL_ASSETS()));
+function summaryToSharesUp(uint256 assets) returns uint256 {
+    uint256 totalAssets = MORPHO.virtualTotalSupplyAssets(currentContract.ID);
+    uint256 totalShares = MORPHO.virtualTotalSupplyShares(currentContract.ID);
+    return Util.libMulDivUp(assets, totalAssets, totalShares);
 }
 
 function summaryToAssetsUp(uint256 shares, uint256 totalAssets, uint256 totalShares) returns uint256 {

--- a/certora/specs/SummaryLib.spec
+++ b/certora/specs/SummaryLib.spec
@@ -9,6 +9,8 @@ methods {
     function MORPHO.borrowShares(PreLiquidation.Id, address) external returns (uint256) envfree;
     function MORPHO.collateral(PreLiquidation.Id, address) external returns (uint256) envfree;
     function MORPHO.lastUpdate(PreLiquidation.Id) external returns (uint256) envfree;
+
+    function Util.libId(PreLiquidation.MarketParams) external returns (PreLiquidation.Id) envfree;
 }
 
 definition WAD() returns uint256 = 10^18;


### PR DESCRIPTION
This PR:
- removes "general getters", ie `market_` and `position_` as we mostly don't need them. This allows in turn to remove some definitions by using `virtualTotal*` getters
- clarifies every `require_uint256`, by factoring all of those that needed to stay into `computeLinearCombination`
- fixes some typos, formats some files and inline some functions
- other simplifications and refactoring